### PR TITLE
chore(template): accept new copier update

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.8.0-28-gec8e125
+_commit: v0.8.0-30-g21f9332
 _src_path: https://github.com/usnistgov/cookiecutter-nist-python.git
 command_line_interface: argparse
 conda_channel: conda-forge

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
       - id: sync-uv-dependency-groups
       - id: justfile-format
         additional_dependencies:
-          - rust-just==1.47.0
+          - rust-just==1.46.0
 
   # * Forbidden files
   - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
       - id: sync-uv-dependency-groups
       - id: justfile-format
         additional_dependencies:
-          - rust-just==1.46.0
+          - rust-just==1.47.0
 
   # * Forbidden files
   - repo: local
@@ -97,7 +97,7 @@ repos:
 
   # * Markdown
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.21.0
+    rev: v0.22.0
     hooks:
       - id: markdownlint-cli2
         alias: markdownlint


### PR DESCRIPTION
This is an autogenerated PR. Use this to merge the changes to this repository. 

Files changed (`git status --short`):
 M .copier-answers.yml
 M .pre-commit-config.yaml

[copier](https://github.com/copier-org/copier) has detected updates from the Cookiecutter repository.