### PR TITLE
chore(template): accept new copier update

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.12.0-184-g88067ae
+_commit: v0.13.0-4-g705c855
 _src_path: https://github.com/usnistgov/cookiecutter-nist-python.git
 command_line_interface: argparse
 conda_channel: conda-forge

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -211,7 +211,7 @@ napoleon_type_aliases = {
     "Series": "~pandas.Series",
     "DataFrame": "~pandas.DataFrame",
     "Categorical": "~pandas.Categorical",
-    "Path": "~~pathlib.Path",
+    "Path": "~pathlib.Path",
     # objects with abbreviated namespace (from pandas)
     "pd.Index": "~pandas.Index",
     "pd.NaT": "~pandas.NaT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ expand_tables = [
     "tool.pytest",
     "tool.typos",
     "tool.uv.dependency-groups",
+    "tool.uv.exclude-newer-package",
 ]
 indent = 4
 keep_full_version = true

--- a/tests/test_open_notebook.py
+++ b/tests/test_open_notebook.py
@@ -4,33 +4,9 @@ from __future__ import annotations
 
 import re
 
-<<<<<<< before updating
-=======
-import pytest
-
-from open_notebook import cli, example_function
-
->>>>>>> after updating
 
 def test_version() -> None:
     from open_notebook import __version__
 
     assert isinstance(__version__, str)
     assert re.match(r"^\d+\.\d+\.\d+.*$", __version__) is not None
-<<<<<<< before updating
-=======
-
-
-@pytest.fixture
-def response() -> tuple[int, int]:
-    return 1, 2
-
-
-def test_example_function(response: tuple[int, int]) -> None:
-    expected = 3
-    assert example_function(*response) == expected
-
-
-def test_command_line_interface() -> None:
-    assert not cli.main([])
->>>>>>> after updating

--- a/tests/test_open_notebook.py
+++ b/tests/test_open_notebook.py
@@ -4,9 +4,33 @@ from __future__ import annotations
 
 import re
 
+<<<<<<< before updating
+=======
+import pytest
+
+from open_notebook import cli, example_function
+
+>>>>>>> after updating
 
 def test_version() -> None:
     from open_notebook import __version__
 
     assert isinstance(__version__, str)
     assert re.match(r"^\d+\.\d+\.\d+.*$", __version__) is not None
+<<<<<<< before updating
+=======
+
+
+@pytest.fixture
+def response() -> tuple[int, int]:
+    return 1, 2
+
+
+def test_example_function(response: tuple[int, int]) -> None:
+    expected = 3
+    assert example_function(*response) == expected
+
+
+def test_command_line_interface() -> None:
+    assert not cli.main([])
+>>>>>>> after updating


### PR DESCRIPTION
This is an autogenerated PR. Use this to merge the changes to this repository. Resolve conflicts.

Files changed (`git status --short`):
 M .copier-answers.yml
 M docs/conf.py
 M pyproject.toml
UU tests/test_open_notebook.py

[copier](https://github.com/copier-org/copier) has detected updates from the Cookiecutter repository.