### PR TITLE
chore(template): accept new copier update

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.13.0-18-g36d2b19
+_commit: v0.13.0-21-g8fc80b9
 _src_path: https://github.com/usnistgov/cookiecutter-nist-python.git
 command_line_interface: argparse
 conda_channel: conda-forge

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -8,7 +8,7 @@ reorder_keys = true
 
 [[rule]]
 include = [ "**/pyproject.toml" ]
-keys = [ "project", "tool.coverage" ]
+keys = [ "project", "tool.coverage", "tool.mypy.overrides" ]
 
 [rule.formatting]
 reorder_arrays = false


### PR DESCRIPTION
This is an autogenerated PR. Use this to merge the changes to this repository. 

Files changed (`git status --short`):
 M .copier-answers.yml
 M .taplo.toml

[copier](https://github.com/copier-org/copier) has detected updates from the Cookiecutter repository.