### PR TITLE
chore(template): accept new copier update

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.13.0-59-g54737f0
+_commit: v0.13.0-76-gc864be4
 _src_path: https://github.com/usnistgov/cookiecutter-nist-python.git
 command_line_interface: argparse
 conda_channel: conda-forge

--- a/.github/actions/setup-cached-uv-and-python/action.yml
+++ b/.github/actions/setup-cached-uv-and-python/action.yml
@@ -31,7 +31,7 @@ runs:
   steps:
     - name: Setup python
       id: setup-python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ inputs.python-version }}
         python-version-file: ${{ inputs.python-version-file }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
           echo "prek_version=${prek_version}" >> "$GITHUB_ENV"
 
       - name: Setup prek
-        uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4
+        uses: j178/prek-action@e98a699c41eb69ab013a45817a0406469a748f8d # v2.0.5
         with:
           prek-version: ${{ env.prek_version }}
           install-only: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Setup python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ">=3.11"
 

--- a/.github/workflows/update-package-version.yml
+++ b/.github/workflows/update-package-version.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Rooster cache
         id: numba-cache-restore
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ${{ github.workspace }}/.cache


### PR DESCRIPTION
This is an autogenerated PR. Use this to merge the changes to this repository. 

Files changed (`git status --short`):
 M .copier-answers.yml
 M .github/actions/setup-cached-uv-and-python/action.yml
 M .github/workflows/ci.yml
 M .github/workflows/release.yml
 M .github/workflows/update-package-version.yml

[copier](https://github.com/copier-org/copier) has detected updates from the Cookiecutter repository.